### PR TITLE
Filter and shader

### DIFF
--- a/jamsepticeye-gj/materials/canvas/fish_eye.tres
+++ b/jamsepticeye-gj/materials/canvas/fish_eye.tres
@@ -1,0 +1,7 @@
+[gd_resource type="ShaderMaterial" load_steps=2 format=3 uid="uid://lw2edqflwthp"]
+
+[ext_resource type="Shader" uid="uid://ccruylberq78q" path="res://materials/shaders/fish_eye.gdshader" id="1_fv4al"]
+
+[resource]
+shader = ExtResource("1_fv4al")
+shader_parameter/fish_intensity = 0.0

--- a/jamsepticeye-gj/materials/canvas/ripple.tres
+++ b/jamsepticeye-gj/materials/canvas/ripple.tres
@@ -1,0 +1,9 @@
+[gd_resource type="ShaderMaterial" load_steps=2 format=3 uid="uid://lsk3sblumwkb"]
+
+[ext_resource type="Shader" uid="uid://dum7vo4toww7b" path="res://Materials/shaders/ripple_canvas.gdshader" id="1_72liw"]
+
+[resource]
+shader = ExtResource("1_72liw")
+shader_parameter/wave_count = 5.0
+shader_parameter/speed = 4.0
+shader_parameter/height = 0.030000001425

--- a/jamsepticeye-gj/materials/canvas/vignette.tres
+++ b/jamsepticeye-gj/materials/canvas/vignette.tres
@@ -1,0 +1,11 @@
+[gd_resource type="ShaderMaterial" load_steps=2 format=3 uid="uid://lbjmnhp7fy0f"]
+
+[ext_resource type="Shader" uid="uid://b6o32ijht41tp" path="res://Materials/shaders/vignette.gdshader" id="1_1r7r6"]
+
+[resource]
+shader = ExtResource("1_1r7r6")
+shader_parameter/radius = 0.70000003325
+shader_parameter/softness = 1.0
+shader_parameter/intensity = 2.0
+shader_parameter/contrast = 2.2
+shader_parameter/vignette_color = Color(0, 0, 0, 1)

--- a/jamsepticeye-gj/materials/shaders/fish_eye.gdshader
+++ b/jamsepticeye-gj/materials/shaders/fish_eye.gdshader
@@ -1,0 +1,45 @@
+shader_type canvas_item;
+uniform sampler2D SCREEN_TEXTURE:hint_screen_texture,filter_linear;
+// 鱼眼效果强度控制
+uniform float fish_intensity : hint_range(0.0, 2.0) = 1.0;
+void fragment() {
+    // 获取屏幕分辨率
+    vec2 iResolution = vec2(textureSize(SCREEN_TEXTURE, 0));
+    // 基础UV坐标（适配Godot坐标系）
+    vec2 uv = UV;
+    uv.y = 1.0 - uv.y; // 翻转Y轴
+
+    // 宽高比计算
+    float aspectRatio = iResolution.x / iResolution.y;
+
+    // 计算强度参数
+    float strength = fish_intensity * 0.03;
+    vec2 intensity = vec2(
+        strength * aspectRatio,
+        strength * aspectRatio
+    );
+
+    // 坐标转换到[-1, 1]范围
+    vec2 coords = uv;
+    coords = (coords - 0.5) * 2.0;
+
+    // 计算坐标偏移量
+    vec2 realCoordOffs;
+    realCoordOffs.x = (1.0 - coords.y * coords.y) * intensity.y * coords.x;
+    realCoordOffs.y = (1.0 - coords.x * coords.x) * intensity.x * coords.y;
+
+    // 应用偏移
+    vec2 fuv = uv - realCoordOffs;
+    // 边界检查
+    if(fuv.x < 0.0 || fuv.x > 1.0 || fuv.y < 0.0 || fuv.y > 1.0) {
+        COLOR = vec4(0.0); // 超出范围显示黑
+		vec4 color = texture(SCREEN_TEXTURE,fuv);
+		COLOR.rgb=mix(color.rgb,color.bgr,length(fuv-0.5));
+    } else {
+        // 采样时再次翻转Y轴适配Godot坐标系
+        fuv.y = 1.0 - fuv.y;
+        COLOR = texture(SCREEN_TEXTURE, fuv);
+		vec4 color = texture(SCREEN_TEXTURE,fuv);
+		COLOR.rgb=mix(color.rgb,color.bgr,length(fuv-0.5));
+    }
+}

--- a/jamsepticeye-gj/materials/shaders/fish_eye.gdshader.uid
+++ b/jamsepticeye-gj/materials/shaders/fish_eye.gdshader.uid
@@ -1,0 +1,1 @@
+uid://ccruylberq78q

--- a/jamsepticeye-gj/materials/shaders/linear_depth_spatial.gdshader
+++ b/jamsepticeye-gj/materials/shaders/linear_depth_spatial.gdshader
@@ -1,0 +1,29 @@
+shader_type spatial;
+render_mode unshaded; // Bỏ depth_draw_never để nó có thể ghi đè lên mọi thứ
+
+uniform float mix_factor : hint_range(0.0, 1.0, 0.01) = 0.0;
+
+uniform float max_depth : hint_range(0.0, 50.0, 0.01) = 5.0;
+
+uniform sampler2D SCREEN_TEXTURE : hint_screen_texture, filter_linear_mipmap;
+
+uniform float depth_factor : hint_range(0.0, 256.0, 0.1) = 80.0;
+
+uniform sampler2D DEPTH_TEXTURE : hint_depth_texture;
+
+uniform vec3 tint : source_color = vec3(1.0, 0.5, 0.5);
+
+void fragment() {
+    vec3 screen_color = texture(SCREEN_TEXTURE, SCREEN_UV).rgb;
+
+    float depth = texture(DEPTH_TEXTURE, SCREEN_UV).r;
+    float linear_depth = 1.0 / (depth * INV_PROJECTION_MATRIX[2].w + INV_PROJECTION_MATRIX[3].w);
+    float depth_normalized = clamp(linear_depth / depth_factor, 0.0, max_depth);
+	vec3 depth_color = tint * depth_normalized;
+
+    vec3 final_color = mix(screen_color, depth_color, mix_factor);
+
+    ALBEDO = final_color;
+
+    ALPHA = mix(1.0, 0.95, mix_factor);
+}

--- a/jamsepticeye-gj/materials/shaders/linear_depth_spatial.gdshader.uid
+++ b/jamsepticeye-gj/materials/shaders/linear_depth_spatial.gdshader.uid
@@ -1,0 +1,1 @@
+uid://cu4y0dnpcr465

--- a/jamsepticeye-gj/materials/shaders/ripple_canvas.gdshader
+++ b/jamsepticeye-gj/materials/shaders/ripple_canvas.gdshader
@@ -1,0 +1,15 @@
+shader_type canvas_item;
+
+uniform float wave_count : hint_range(1.0, 20.0, 1.0) = 3.0;
+uniform float speed : hint_range(0.0, 10.0, 0.1) = 4.0;
+uniform float height : hint_range(0.0, 0.1, 0.001) = 0.03;
+
+uniform sampler2D screen_texture : hint_screen_texture, repeat_disable, filter_nearest;
+
+void fragment() {
+vec2 cPos = -1.0 + 2.0 * UV;
+float cLength = length(cPos);
+vec2 uv = SCREEN_UV + (cPos/cLength) * cos(cLength * wave_count - TIME * speed) * height;
+  vec3 col = textureLod(screen_texture,uv, 0.0).xyz;
+COLOR = vec4(col,1.0);
+}

--- a/jamsepticeye-gj/materials/shaders/ripple_canvas.gdshader.uid
+++ b/jamsepticeye-gj/materials/shaders/ripple_canvas.gdshader.uid
@@ -1,0 +1,1 @@
+uid://dum7vo4toww7b

--- a/jamsepticeye-gj/materials/shaders/vignette.gdshader
+++ b/jamsepticeye-gj/materials/shaders/vignette.gdshader
@@ -1,0 +1,31 @@
+shader_type canvas_item;
+
+// Stronger defaults
+uniform float radius:    hint_range(0.0, 1.0) = 0.22;  // where darkening starts (smaller = more encroachment)
+uniform float softness:  hint_range(0.0, 1.0) = 0.38;  // feather width toward center
+uniform float intensity: hint_range(0.0, 3.0) = 2.00;  // overall darkness
+uniform float contrast:  hint_range(0.5, 4.0) = 2.20;  // >1.0 sharpens falloff
+uniform vec4 vignette_color: source_color = vec4(0.0, 0.0, 0.0, 1.0);
+
+void fragment() {
+    vec2 uv = SCREEN_UV;
+    vec2 centered = uv - vec2(0.5);
+
+    // Edge-driven shape (0 at center, 1 at edges):
+    // Chebyshev distance = pushes from ALL edges uniformly
+    float edge_box = max(abs(centered.x) * 2.0, abs(centered.y) * 2.0);
+
+    // Blend a little radial in to avoid a "boxy" look (optional)
+    float edge_radial = length(centered) * 2.0; // 0 center -> ~1 corners
+    float shape = mix(edge_box, edge_radial, 0.25);
+
+    // Darken from radius inward with feather = softness
+    float v = smoothstep(radius, radius + softness, shape);
+    v = pow(v, contrast);
+
+    vec4 overlay = vignette_color;
+    overlay.a = clamp(v * intensity, 0.0, 1.0);
+
+    // Output just the vignette color/alpha (use on a full-screen ColorRect)
+    COLOR = overlay;
+}

--- a/jamsepticeye-gj/materials/shaders/vignette.gdshader.uid
+++ b/jamsepticeye-gj/materials/shaders/vignette.gdshader.uid
@@ -1,0 +1,1 @@
+uid://b6o32ijht41tp

--- a/jamsepticeye-gj/materials/spatial/linear_depth.tres
+++ b/jamsepticeye-gj/materials/spatial/linear_depth.tres
@@ -1,0 +1,11 @@
+[gd_resource type="ShaderMaterial" load_steps=2 format=3 uid="uid://cj181dtn4uy2v"]
+
+[ext_resource type="Shader" uid="uid://cu4y0dnpcr465" path="res://Materials/shaders/linear_depth_spatial.gdshader" id="1_f5p6t"]
+
+[resource]
+render_priority = 0
+shader = ExtResource("1_f5p6t")
+shader_parameter/mix_factor = 1.0
+shader_parameter/max_depth = 5.0
+shader_parameter/depth_factor = 80.0
+shader_parameter/tint = Color(0.02745098, 0.5019608, 0.5019608, 1)

--- a/jamsepticeye-gj/materials/spatial/linear_depth.tres
+++ b/jamsepticeye-gj/materials/spatial/linear_depth.tres
@@ -5,7 +5,7 @@
 [resource]
 render_priority = 0
 shader = ExtResource("1_f5p6t")
-shader_parameter/mix_factor = 1.0
+shader_parameter/mix_factor = 0.0
 shader_parameter/max_depth = 5.0
 shader_parameter/depth_factor = 80.0
 shader_parameter/tint = Color(0.02745098, 0.5019608, 0.5019608, 1)

--- a/jamsepticeye-gj/scenes/components/camera_overlay.gd
+++ b/jamsepticeye-gj/scenes/components/camera_overlay.gd
@@ -1,0 +1,45 @@
+extends Node3D
+
+@onready var canvas_overlay: Control = UIManager.canvas_overlay
+
+@onready var linear_depth_effect: MeshInstance3D = $LinearDepthEffect
+
+func _physics_process(delta: float) -> void:
+	if(Input.is_action_just_pressed("move_forward")):
+		#canvas_overlay._show_ripple_effect()
+		if(!is_linear_depth):
+			_linear_depth_tween(1)
+		is_linear_depth = true
+		#canvas_overlay._show_vignette_effect()
+
+		#show_linear_depth_effect()
+	if(Input.is_action_just_pressed("move_back")):
+		if(is_linear_depth):
+			_linear_depth_tween(0)
+		is_linear_depth = false
+		#canvas_overlay._hide_vignette_effect()
+
+		#canvas_overlay._hide_ripple_effect()
+		#hide_linear_depth_effect()
+	##if(Input.is_action_just_pressed("move_left")):
+		##canvas_overlay._show_vignette_effect()
+	##if(Input.is_action_just_pressed("move_right")):
+		##canvas_overlay._hide_vignette_effect()
+
+
+var show_linear_depth_tween: Tween = null
+var is_linear_depth = false
+
+func _linear_depth_tween(p_target_value: float, duration: float = 0.3) -> void:
+
+	if show_linear_depth_tween != null and show_linear_depth_tween.is_valid():
+		canvas_overlay._hide_ripple_effect()
+		show_linear_depth_tween.kill()
+		
+	canvas_overlay._show_ripple_effect()
+	var mat = linear_depth_effect.get_active_material(0)
+	
+	show_linear_depth_tween = create_tween()
+	show_linear_depth_tween.tween_property(mat, "shader_parameter/mix_factor", p_target_value, duration)
+	await show_linear_depth_tween.finished
+	canvas_overlay._hide_ripple_effect()

--- a/jamsepticeye-gj/scenes/components/camera_overlay.gd.uid
+++ b/jamsepticeye-gj/scenes/components/camera_overlay.gd.uid
@@ -1,0 +1,1 @@
+uid://bu4secvt3bo2u

--- a/jamsepticeye-gj/scenes/components/player.tscn
+++ b/jamsepticeye-gj/scenes/components/player.tscn
@@ -1,7 +1,9 @@
-[gd_scene load_steps=7 format=3 uid="uid://bi1fcsxwupdxd"]
+[gd_scene load_steps=11 format=3 uid="uid://bi1fcsxwupdxd"]
 
 [ext_resource type="Script" uid="uid://dm5h47oxmhnrp" path="res://scripts/player.gd" id="1_6mmc7"]
 [ext_resource type="PackedScene" uid="uid://5dreldwpi40r" path="res://scenes/components/ghost.tscn" id="2_h3cwf"]
+[ext_resource type="Script" uid="uid://bu4secvt3bo2u" path="res://scenes/components/camera_overlay.gd" id="3_acvb7"]
+[ext_resource type="Material" uid="uid://cj181dtn4uy2v" path="res://Materials/spatial/linear_depth.tres" id="3_sjsxr"]
 
 [sub_resource type="CapsuleShape3D" id="CapsuleShape3D_h3cwf"]
 radius = 0.3
@@ -18,6 +20,12 @@ height = 0.3
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_h3cwf"]
 albedo_color = Color(0.9552701, 0.41789043, 1.92523e-07, 1)
+
+[sub_resource type="Environment" id="Environment_acvb7"]
+
+[sub_resource type="QuadMesh" id="QuadMesh_h3cwf"]
+material = ExtResource("3_sjsxr")
+size = Vector2(2, 2)
 
 [node name="Player" type="CharacterBody3D"]
 collision_layer = 0
@@ -44,5 +52,16 @@ unique_name_in_owner = true
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.2, 0)
 
 [node name="Camera3D" type="Camera3D" parent="CamPivot"]
+environment = SubResource("Environment_acvb7")
+
+[node name="CameraOverlay" type="Node3D" parent="CamPivot/Camera3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -0.09656106)
+script = ExtResource("3_acvb7")
+
+[node name="LinearDepthEffect" type="MeshInstance3D" parent="CamPivot/Camera3D/CameraOverlay"]
+transform = Transform3D(1, 0, 0, 0, 0.9999973, -0.0023038324, 0, 0.0023038324, 0.9999973, 0, 0, 0)
+cast_shadow = 0
+mesh = SubResource("QuadMesh_h3cwf")
+skeleton = NodePath("../..")
 
 [node name="AudioListener3D" type="AudioListener3D" parent="."]

--- a/jamsepticeye-gj/scenes/components/ui_manager.tscn
+++ b/jamsepticeye-gj/scenes/components/ui_manager.tscn
@@ -1,9 +1,13 @@
-[gd_scene load_steps=7 format=3 uid="uid://dej2888vlmdd8"]
+[gd_scene load_steps=11 format=3 uid="uid://dej2888vlmdd8"]
 
 [ext_resource type="Script" uid="uid://ct2pb3ccvpyit" path="res://scripts/ui_manager.gd" id="1_ixhu3"]
+[ext_resource type="Script" uid="uid://c0ixa2n2lknay" path="res://scripts/canvas_overlay.gd" id="2_etoot"]
 [ext_resource type="PackedScene" uid="uid://dfma1x4vpjig2" path="res://scenes/components/ui_main.tscn" id="2_gl862"]
+[ext_resource type="Material" uid="uid://lsk3sblumwkb" path="res://Materials/canvas/ripple.tres" id="3_fnrs7"]
 [ext_resource type="PackedScene" uid="uid://dsmv4yrsau6xy" path="res://scenes/components/ui_pause.tscn" id="3_hst8a"]
+[ext_resource type="Material" uid="uid://lbjmnhp7fy0f" path="res://Materials/canvas/vignette.tres" id="4_13u4i"]
 [ext_resource type="PackedScene" uid="uid://bf5knpqguv2r1" path="res://scenes/components/ui_options.tscn" id="4_tanoa"]
+[ext_resource type="Material" uid="uid://lw2edqflwthp" path="res://Materials/canvas/fish_eye.tres" id="5_eutd8"]
 [ext_resource type="PackedScene" uid="uid://s7ma42yxvhwv" path="res://scenes/components/ui_ingame.tscn" id="5_jo33p"]
 
 [sub_resource type="Theme" id="Theme_0wfyh"]
@@ -21,6 +25,51 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 theme = SubResource("Theme_0wfyh")
 script = ExtResource("1_ixhu3")
+
+[node name="CanvasOverlay" type="Control" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("2_etoot")
+
+[node name="RippleEffect" type="ColorRect" parent="CanvasOverlay"]
+visible = false
+z_index = -1
+material = ExtResource("3_fnrs7")
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0, 1, 1, 0.23921569)
+
+[node name="VignetteEffect" type="ColorRect" parent="CanvasOverlay"]
+visible = false
+z_index = -1
+material = ExtResource("4_13u4i")
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0, 1, 1, 0.23921569)
+
+[node name="FishEyeEffect" type="ColorRect" parent="CanvasOverlay"]
+visible = false
+z_index = -1
+material = ExtResource("5_eutd8")
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0, 1, 1, 0.23921569)
 
 [node name="ui_main" parent="." instance=ExtResource("2_gl862")]
 visible = false

--- a/jamsepticeye-gj/scenes/visual.tscn
+++ b/jamsepticeye-gj/scenes/visual.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=11 format=3 uid="uid://dncheeietg615"]
+[gd_scene load_steps=12 format=3 uid="uid://clfwmm61q55ye"]
 
-[ext_resource type="Material" uid="uid://8c76kywocjsl" path="res://Materials/DungeonWall_Color.tres" id="1_ppgk2"]
-[ext_resource type="PackedScene" uid="uid://by3bdi2fa451q" path="res://Prefabs/Dungeon_WallPillar.glb" id="2_2r41h"]
-[ext_resource type="PackedScene" uid="uid://br41ag8tiywo0" path="res://Prefabs/Dungeon_DoorFrame.glb" id="4_b121j"]
-[ext_resource type="PackedScene" uid="uid://dh2paf7fk7fah" path="res://scenes/dungeon_wall.tscn" id="4_mx8sn"]
+[ext_resource type="PackedScene" uid="uid://br41ag8tiywo0" path="res://Prefabs/Dungeon_DoorFrame.glb" id="1_5h6hl"]
+[ext_resource type="PackedScene" uid="uid://by3bdi2fa451q" path="res://Prefabs/Dungeon_WallPillar.glb" id="1_fixx2"]
+[ext_resource type="Material" uid="uid://8c76kywocjsl" path="res://Materials/DungeonWall_Color.tres" id="1_tpt3i"]
+[ext_resource type="PackedScene" uid="uid://jtl70ydxfkxb" path="res://Prefabs/Dungeon_Wall.glb" id="2_5h6hl"]
+[ext_resource type="PackedScene" uid="uid://cqgkjpa2vjsks" path="res://Prefabs/Dungeon_GateDoor.glb" id="4_wic5t"]
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_tpt3i"]
 albedo_color = Color(0.17233449, 0.18400723, 0.3156101, 1)
@@ -23,22 +24,16 @@ albedo_color = Color(0.2660402, 0.1787613, 1, 1)
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_aayvh"]
 albedo_color = Color(1.1310726e-06, 0.63421637, 9.62615e-07, 1)
 
-[node name="Level" type="Node3D"]
-transform = Transform3D(0.58, 0, 0, 0, 0.58, 0, 0, 0, 0.58, 0, 0, 0)
+[node name="Visual" type="Node"]
 
 [node name="Environment" type="CSGCombiner3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -23, 0, 0)
-material_override = ExtResource("1_ppgk2")
+material_override = ExtResource("1_tpt3i")
 use_collision = true
-
-[node name="Roof" type="CSGBox3D" parent="Environment"]
-transform = Transform3D(1.0000004, 0, 0, 0, 1.0000004, 0, 0, 0, 1.0000004, 23.9494, 6.2050743, -3.9589865)
-material_override = ExtResource("1_ppgk2")
-size = Vector3(80.25, 0.060791016, 89)
 
 [node name="Floor" type="CSGBox3D" parent="Environment"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 23.49408, 0.08529124, -3.9794922)
-material_override = ExtResource("1_ppgk2")
+material_override = ExtResource("1_tpt3i")
 size = Vector3(79, 0.060791016, 40)
 
 [node name="CSGBox3D9" type="CSGBox3D" parent="Environment"]
@@ -185,202 +180,228 @@ size = Vector3(1, 6, 0.546)
 transform = Transform3D(-4.371139e-08, 0, -60.259125, 0, 1, 0, 1, 0, -2.6340101e-06, 16.06567, 3.1661692, 40.031563)
 size = Vector3(1, 6, 0.553)
 
-[node name="Doors" type="Node3D" parent="."]
+[node name="Doors" type="Node" parent="."]
 
 [node name="DoorCA" type="CSGBox3D" parent="Doors"]
 transform = Transform3D(1.1965497, 0, 0, 0, 3.911552, 0, 0, 0, 6.6133447, -13.38504, 1.6143091, 9.812071)
-visible = false
 material_override = SubResource("StandardMaterial3D_ag826")
 size = Vector3(1.2250977, 0.77783203, 0.47299194)
 
 [node name="DoorOA" type="CSGBox3D" parent="Doors"]
 transform = Transform3D(1.6408973, 0, 0, 0, 3.911552, 0, 0, 0, 6.6133447, -25.807005, 1.4223603, -17.372898)
-visible = false
 material_override = SubResource("StandardMaterial3D_ag826")
 size = Vector3(1, 0.6796875, 0.47395325)
 
 [node name="DoorCB" type="CSGBox3D" parent="Doors"]
 transform = Transform3D(1.1965497, 0, 0, 0, 3.911552, 0, 0, 0, 6.6133447, -25.497618, 1.3949859, -3.7690597)
-visible = false
 material_override = SubResource("StandardMaterial3D_fixx2")
 size = Vector3(1.2741699, 0.6425781, 0.4789009)
 
 [node name="DoorOB" type="CSGBox3D" parent="Doors"]
 transform = Transform3D(1.1965497, 0, 0, 0, 3.911552, 0, 0, 0, 6.6133447, 10.300168, 1.3949859, -17.389011)
-visible = false
 material_override = SubResource("StandardMaterial3D_fixx2")
 size = Vector3(1.2741699, 0.6425781, 0.48582935)
 
 [node name="DoorOD" type="CSGBox3D" parent="Doors"]
 transform = Transform3D(1.1965497, 0, 0, 0, 3.911552, 0, 0, 0, 6.6133447, 10.300168, 1.3949859, -3.766706)
-visible = false
 material_override = SubResource("StandardMaterial3D_5h6hl")
 size = Vector3(1.2741699, 0.6425781, 0.48203468)
 
 [node name="DoorCD" type="CSGBox3D" parent="Doors"]
 transform = Transform3D(1.1965497, 0, 0, 0, 3.911552, 0, 0, 0, 6.6133447, 39.792877, 1.3949859, -20.924402)
-visible = false
 material_override = SubResource("StandardMaterial3D_5h6hl")
 size = Vector3(1.2741699, 0.6425781, 0.47629738)
 
 [node name="DoorCC" type="CSGBox3D" parent="Doors"]
 transform = Transform3D(1.1965497, 0, 0, 0, 3.911552, 0, 0, 0, 6.6133447, 0.048074365, 1.6708909, -3.676495)
-visible = false
 material_override = SubResource("StandardMaterial3D_aayvh")
 size = Vector3(1.1876221, 0.8067627, 0.4873352)
 
 [node name="DoorOC" type="CSGBox3D" parent="Doors"]
 transform = Transform3D(1.1965497, 0, 0, 0, 3.911552, 0, 0, 0, 6.6133447, -25.467337, 1.4223603, 9.755863)
-visible = false
 material_override = SubResource("StandardMaterial3D_aayvh")
 size = Vector3(1.1876221, 0.6796875, 0.63049316)
 
-[node name="Levers" type="Node3D" parent="."]
+[node name="Levers" type="Node" parent="."]
 
 [node name="LeverA" type="CSGBox3D" parent="Levers"]
 transform = Transform3D(1.1965497, 0, 0, 0, 3.911552, 0, 0, 0, 6.6133447, -27.192335, 1.3949859, 1.0587953)
-visible = false
 material_override = SubResource("StandardMaterial3D_ag826")
 size = Vector3(1.1333008, 0.6425781, 0.26202393)
 
 [node name="LeverB" type="CSGBox3D" parent="Levers"]
 transform = Transform3D(1.1965497, 0, 0, 0, 3.911552, 0, 0, 0, 6.6133447, -27.192335, 1.3949859, 4.9239254)
-visible = false
 material_override = SubResource("StandardMaterial3D_fixx2")
 size = Vector3(1.1333008, 0.6425781, 0.26202393)
 
 [node name="LeverC" type="CSGBox3D" parent="Levers"]
 transform = Transform3D(1.1965497, 0, 0, 0, 3.911552, 0, 0, 0, 6.6133447, -29.362358, 1.4223603, -23.063732)
-visible = false
 material_override = SubResource("StandardMaterial3D_aayvh")
 size = Vector3(1.7073059, 0.6796875, 0.14727783)
 
 [node name="LeverD" type="CSGBox3D" parent="Levers"]
 transform = Transform3D(1.1965497, 0, 0, 0, 3.911552, 0, 0, 0, 6.6133447, -4.8088555, 1.3949859, -8.854521)
-visible = false
 material_override = SubResource("StandardMaterial3D_5h6hl")
 size = Vector3(1.6848145, 0.6425781, 0.2103653)
 
-[node name="Dungeon_Env" type="Node3D" parent="."]
+[node name="Dungeon_Env" type="Node" parent="."]
 
-[node name="Dungeon_WallPillar" parent="Dungeon_Env" instance=ExtResource("2_2r41h")]
+[node name="Dungeon_WallPillar" parent="Dungeon_Env" instance=ExtResource("1_fixx2")]
 transform = Transform3D(1.7, 0, 0, 0, 1.7, 0, 0, 0, 1.7, -25.388298, 0, 15.545013)
 
-[node name="Dungeon_WallPillar4" parent="Dungeon_Env" instance=ExtResource("2_2r41h")]
+[node name="Dungeon_WallPillar4" parent="Dungeon_Env" instance=ExtResource("1_fixx2")]
 transform = Transform3D(1.7, 0, 0, 0, 1.7, 0, 0, 0, 1.7, -38.988297, 0, 15.545013)
 
-[node name="Dungeon_WallPillar2" parent="Dungeon_Env" instance=ExtResource("2_2r41h")]
+[node name="Dungeon_WallPillar2" parent="Dungeon_Env" instance=ExtResource("1_fixx2")]
 transform = Transform3D(1.7, 0, 0, 0, 1.7, 0, 0, 0, 1.7, -25.388298, 0, 3.645013)
 
-[node name="Dungeon_WallPillar3" parent="Dungeon_Env" instance=ExtResource("2_2r41h")]
+[node name="Dungeon_WallPillar3" parent="Dungeon_Env" instance=ExtResource("1_fixx2")]
 transform = Transform3D(1.7, 0, 0, 0, 1.7, 0, 0, 0, 1.7, -25.388298, 0, 1.945013)
 
-[node name="Dungeon_WallPillar5" parent="Dungeon_Env" instance=ExtResource("2_2r41h")]
+[node name="Dungeon_WallPillar5" parent="Dungeon_Env" instance=ExtResource("1_fixx2")]
 transform = Transform3D(1.7, 0, 0, 0, 1.7, 0, 0, 0, 1.7, -38.988297, 0, 3.645013)
 
-[node name="Dungeon_WallPillar13" parent="Dungeon_Env" instance=ExtResource("2_2r41h")]
+[node name="Dungeon_WallPillar13" parent="Dungeon_Env" instance=ExtResource("1_fixx2")]
 transform = Transform3D(1.7, 0, 0, 0, 1.7, 0, 0, 0, 1.7, 0.111701965, 0, 15.545013)
 
-[node name="Dungeon_WallPillar14" parent="Dungeon_Env" instance=ExtResource("2_2r41h")]
+[node name="Dungeon_WallPillar14" parent="Dungeon_Env" instance=ExtResource("1_fixx2")]
 transform = Transform3D(1.7, 0, 0, 0, 1.7, 0, 0, 0, 1.7, -13.4882965, 0, 15.545013)
 
-[node name="Dungeon_WallPillar15" parent="Dungeon_Env" instance=ExtResource("2_2r41h")]
+[node name="Dungeon_WallPillar15" parent="Dungeon_Env" instance=ExtResource("1_fixx2")]
 transform = Transform3D(1.7, 0, 0, 0, 1.7, 0, 0, 0, 1.7, 0.111701965, 0, 3.645013)
 
-[node name="Dungeon_WallPillar16" parent="Dungeon_Env" instance=ExtResource("2_2r41h")]
+[node name="Dungeon_WallPillar16" parent="Dungeon_Env" instance=ExtResource("1_fixx2")]
 transform = Transform3D(1.7, 0, 0, 0, 1.7, 0, 0, 0, 1.7, -13.4882965, 0, 3.645013)
 
-[node name="Dungeon_WallPillar17" parent="Dungeon_Env" instance=ExtResource("2_2r41h")]
+[node name="Dungeon_WallPillar17" parent="Dungeon_Env" instance=ExtResource("1_fixx2")]
 transform = Transform3D(1.7, 0, 0, 0, 1.7, 0, 0, 0, 1.7, 0.111701965, 0, 1.945013)
 
-[node name="Dungeon_WallPillar18" parent="Dungeon_Env" instance=ExtResource("2_2r41h")]
+[node name="Dungeon_WallPillar18" parent="Dungeon_Env" instance=ExtResource("1_fixx2")]
 transform = Transform3D(1.7, 0, 0, 0, 1.7, 0, 0, 0, 1.7, -13.4882965, 0, 1.945013)
 
-[node name="Dungeon_WallPillar19" parent="Dungeon_Env" instance=ExtResource("2_2r41h")]
+[node name="Dungeon_WallPillar19" parent="Dungeon_Env" instance=ExtResource("1_fixx2")]
 transform = Transform3D(1.7, 0, 0, 0, 1.7, 0, 0, 0, 1.7, 0.111701965, 0, -9.954988)
 
-[node name="Dungeon_WallPillar20" parent="Dungeon_Env" instance=ExtResource("2_2r41h")]
+[node name="Dungeon_WallPillar20" parent="Dungeon_Env" instance=ExtResource("1_fixx2")]
 transform = Transform3D(1.7, 0, 0, 0, 1.7, 0, 0, 0, 1.7, -13.4882965, 0, -9.954988)
 
-[node name="Dungeon_WallPillar21" parent="Dungeon_Env" instance=ExtResource("2_2r41h")]
+[node name="Dungeon_WallPillar21" parent="Dungeon_Env" instance=ExtResource("1_fixx2")]
 transform = Transform3D(1.7, 0, 0, 0, 1.7, 0, 0, 0, 1.7, 23.911703, 0, 1.945013)
 
-[node name="Dungeon_WallPillar22" parent="Dungeon_Env" instance=ExtResource("2_2r41h")]
+[node name="Dungeon_WallPillar22" parent="Dungeon_Env" instance=ExtResource("1_fixx2")]
 transform = Transform3D(1.7, 0, 0, 0, 1.7, 0, 0, 0, 1.7, 10.311705, 0, 1.945013)
 
-[node name="Dungeon_WallPillar23" parent="Dungeon_Env" instance=ExtResource("2_2r41h")]
+[node name="Dungeon_WallPillar23" parent="Dungeon_Env" instance=ExtResource("1_fixx2")]
 transform = Transform3D(1.7, 0, 0, 0, 1.7, 0, 0, 0, 1.7, 23.911703, 0, -9.954988)
 
-[node name="Dungeon_WallPillar24" parent="Dungeon_Env" instance=ExtResource("2_2r41h")]
+[node name="Dungeon_WallPillar24" parent="Dungeon_Env" instance=ExtResource("1_fixx2")]
 transform = Transform3D(1.7, 0, 0, 0, 1.7, 0, 0, 0, 1.7, 10.311705, 0, -9.954988)
 
-[node name="Dungeon_WallPillar25" parent="Dungeon_Env" instance=ExtResource("2_2r41h")]
+[node name="Dungeon_WallPillar25" parent="Dungeon_Env" instance=ExtResource("1_fixx2")]
 transform = Transform3D(1.7, 0, 0, 0, 1.7, 0, 0, 0, 1.7, 23.911703, 0, -11.654987)
 
-[node name="Dungeon_WallPillar26" parent="Dungeon_Env" instance=ExtResource("2_2r41h")]
+[node name="Dungeon_WallPillar26" parent="Dungeon_Env" instance=ExtResource("1_fixx2")]
 transform = Transform3D(1.7, 0, 0, 0, 1.7, 0, 0, 0, 1.7, 10.311705, 0, -11.654987)
 
-[node name="Dungeon_WallPillar27" parent="Dungeon_Env" instance=ExtResource("2_2r41h")]
+[node name="Dungeon_WallPillar27" parent="Dungeon_Env" instance=ExtResource("1_fixx2")]
 transform = Transform3D(1.7, 0, 0, 0, 1.7, 0, 0, 0, 1.7, 23.911703, 0, -23.554989)
 
-[node name="Dungeon_WallPillar28" parent="Dungeon_Env" instance=ExtResource("2_2r41h")]
+[node name="Dungeon_WallPillar28" parent="Dungeon_Env" instance=ExtResource("1_fixx2")]
 transform = Transform3D(1.7, 0, 0, 0, 1.7, 0, 0, 0, 1.7, 10.311705, 0, -23.554989)
 
-[node name="Dungeon_WallPillar6" parent="Dungeon_Env" instance=ExtResource("2_2r41h")]
+[node name="Dungeon_WallPillar6" parent="Dungeon_Env" instance=ExtResource("1_fixx2")]
 transform = Transform3D(1.7, 0, 0, 0, 1.7, 0, 0, 0, 1.7, -38.988297, 0, 1.945013)
 
-[node name="Dungeon_WallPillar7" parent="Dungeon_Env" instance=ExtResource("2_2r41h")]
+[node name="Dungeon_WallPillar7" parent="Dungeon_Env" instance=ExtResource("1_fixx2")]
 transform = Transform3D(1.7, 0, 0, 0, 1.7, 0, 0, 0, 1.7, -25.388298, 0, -9.954988)
 
-[node name="Dungeon_WallPillar8" parent="Dungeon_Env" instance=ExtResource("2_2r41h")]
+[node name="Dungeon_WallPillar8" parent="Dungeon_Env" instance=ExtResource("1_fixx2")]
 transform = Transform3D(1.7, 0, 0, 0, 1.7, 0, 0, 0, 1.7, -38.988297, 0, -9.954988)
 
-[node name="Dungeon_WallPillar9" parent="Dungeon_Env" instance=ExtResource("2_2r41h")]
+[node name="Dungeon_WallPillar9" parent="Dungeon_Env" instance=ExtResource("1_fixx2")]
 transform = Transform3D(1.7, 0, 0, 0, 1.7, 0, 0, 0, 1.7, -25.388298, 0, -11.654987)
 
-[node name="Dungeon_WallPillar10" parent="Dungeon_Env" instance=ExtResource("2_2r41h")]
+[node name="Dungeon_WallPillar10" parent="Dungeon_Env" instance=ExtResource("1_fixx2")]
 transform = Transform3D(1.7, 0, 0, 0, 1.7, 0, 0, 0, 1.7, -38.988297, 0, -11.654987)
 
-[node name="Dungeon_WallPillar11" parent="Dungeon_Env" instance=ExtResource("2_2r41h")]
+[node name="Dungeon_WallPillar11" parent="Dungeon_Env" instance=ExtResource("1_fixx2")]
 transform = Transform3D(1.7, 0, 0, 0, 1.7, 0, 0, 0, 1.7, -25.388298, 0, -23.554989)
 
-[node name="Dungeon_WallPillar12" parent="Dungeon_Env" instance=ExtResource("2_2r41h")]
+[node name="Dungeon_WallPillar12" parent="Dungeon_Env" instance=ExtResource("1_fixx2")]
 transform = Transform3D(1.7, 0, 0, 0, 1.7, 0, 0, 0, 1.7, -38.988297, 0, -23.554989)
 
-[node name="Dungeon_Corridor" type="Node3D" parent="."]
+[node name="Dungeon_Wall" parent="Dungeon_Env" instance=ExtResource("2_5h6hl")]
+transform = Transform3D(-7.430936e-08, 0, 1.7, 0, 1.7, 0, -1.7, 0, -7.430936e-08, -32.300274, 0, 9.825563)
 
-[node name="Dungeon_DoorFrame3" parent="Dungeon_Corridor" instance=ExtResource("4_b121j")]
+[node name="Dungeon_Wall4" parent="Dungeon_Env" instance=ExtResource("2_5h6hl")]
+transform = Transform3D(2.229281e-07, 0, -1.7, 0, 1.7, 0, 1.7, 0, 2.229281e-07, -6.670578, 0, 9.8255625)
+
+[node name="Dungeon_Wall5" parent="Dungeon_Env" instance=ExtResource("2_5h6hl")]
+transform = Transform3D(-7.4309376e-08, 0, 1.7, 0, 1.7, 0, -1.7, 0, -7.4309376e-08, -6.67058, 0, -3.774438)
+
+[node name="Dungeon_Wall6" parent="Dungeon_Env" instance=ExtResource("2_5h6hl")]
+transform = Transform3D(-7.430935e-08, 0, -1.7, 0, 1.7, 0, 1.7, 0, -7.430935e-08, 17.129421, 0, -17.37444)
+
+[node name="Dungeon_Wall7" parent="Dungeon_Env" instance=ExtResource("2_5h6hl")]
+transform = Transform3D(-7.430935e-08, 0, -1.7, 0, 1.7, 0, 1.7, 0, -7.430935e-08, 17.129421, 0, -3.7744389)
+
+[node name="Dungeon_Wall2" parent="Dungeon_Env" instance=ExtResource("2_5h6hl")]
+transform = Transform3D(-7.430936e-08, 0, 1.7, 0, 1.7, 0, -1.7, 0, -7.430936e-08, -32.300274, 0, -3.7744372)
+
+[node name="Dungeon_Wall3" parent="Dungeon_Env" instance=ExtResource("2_5h6hl")]
+transform = Transform3D(-7.430936e-08, 0, 1.7, 0, 1.7, 0, -1.7, 0, -7.430936e-08, -32.300274, 0, -17.374437)
+
+[node name="Dungeon_Corridor" type="Node" parent="."]
+
+[node name="Dungeon_DoorFrame3" parent="Dungeon_Corridor" instance=ExtResource("1_5h6hl")]
 transform = Transform3D(1.6481333, 0, 0, 0, 1.7, 0, 0, 0, 5.8957725, -2.4596229, 0, -24.221975)
 
-[node name="Dungeon_DoorFrame4" parent="Dungeon_Corridor" instance=ExtResource("4_b121j")]
+[node name="Dungeon_DoorFrame4" parent="Dungeon_Corridor" instance=ExtResource("1_5h6hl")]
 transform = Transform3D(1.6481333, 0, 0, 0, 1.7, 0, 0, 0, 5.8957725, 31.915228, 0, -24.221975)
 
-[node name="Dungeon_DoorFrame5" parent="Dungeon_Corridor" instance=ExtResource("4_b121j")]
+[node name="Dungeon_DoorFrame5" parent="Dungeon_Corridor" instance=ExtResource("1_5h6hl")]
 transform = Transform3D(-7.204219e-08, 0, -5.8957725, 0, 1.7, 0, 1.6481333, 0, -2.577124e-07, 40.07259, 0, -20.96299)
 
-[node name="Dungeon_DoorFrame6" parent="Dungeon_Corridor" instance=ExtResource("4_b121j")]
+[node name="Dungeon_DoorFrame6" parent="Dungeon_Corridor" instance=ExtResource("1_5h6hl")]
 transform = Transform3D(1.6481333, 0, 0, 0, 1.7, 0, 0, 0, 5.8957725, 5.5450954, 0, 16.325087)
 
-[node name="Dungeon_DoorFrame7" parent="Dungeon_Corridor" instance=ExtResource("4_b121j")]
+[node name="Dungeon_DoorFrame7" parent="Dungeon_Corridor" instance=ExtResource("1_5h6hl")]
 transform = Transform3D(1.6481333, 0, 0, 0, 1.7, 0, 0, 0, 5.8957725, -19.187433, 0, 16.325087)
 
-[node name="Dungeon_Wall" parent="." instance=ExtResource("4_mx8sn")]
-transform = Transform3D(-7.430936e-08, 0, -1.7, 0, 1.7, 0, 1.7, 0, -7.430936e-08, -7, 0, 10)
+[node name="IronBar_Gates" type="Node" parent="."]
 
-[node name="Dungeon_Wall2" parent="." instance=ExtResource("4_mx8sn")]
-transform = Transform3D(-7.430936e-08, 0, 1.7, 0, 1.7, 0, -1.7, 0, -7.430936e-08, -7, 0, -4)
+[node name="Dungeon_GateDoor3" parent="IronBar_Gates" instance=ExtResource("4_wic5t")]
+transform = Transform3D(1.7, 0, 0, 0, 1.7, 0, 0, 0, 1.7, -2.4577847, 0.32064247, -24.182041)
 
-[node name="Dungeon_Wall3" parent="." instance=ExtResource("4_mx8sn")]
-transform = Transform3D(-7.430936e-08, 0, 1.7, 0, 1.7, 0, -1.7, 0, -7.430936e-08, -32, 0, 10)
+[node name="Dungeon_GateDoor8" parent="IronBar_Gates" instance=ExtResource("4_wic5t")]
+transform = Transform3D(-7.430936e-08, 0, 1.7, 0, 1.7, 0, -1.7, 0, -7.430936e-08, 10.329718, 0.31079388, -17.386341)
 
-[node name="Dungeon_Wall4" parent="." instance=ExtResource("4_mx8sn")]
-transform = Transform3D(-7.430936e-08, 0, 1.7, 0, 1.7, 0, -1.7, 0, -7.430936e-08, -32, 0, -4)
+[node name="Dungeon_GateDoor9" parent="IronBar_Gates" instance=ExtResource("4_wic5t")]
+transform = Transform3D(-7.430936e-08, 0, 1.7, 0, 1.7, 0, -1.7, 0, -7.430936e-08, 10.329719, 0.31079388, -3.7516866)
 
-[node name="Dungeon_Wall5" parent="." instance=ExtResource("4_mx8sn")]
-transform = Transform3D(-7.430936e-08, 0, 1.7, 0, 1.7, 0, -1.7, 0, -7.430936e-08, -32, 0, -17)
+[node name="Dungeon_GateDoor12" parent="IronBar_Gates" instance=ExtResource("4_wic5t")]
+transform = Transform3D(-7.430936e-08, 0, 1.7, 0, 1.7, 0, -1.7, 0, -7.430936e-08, 0.12971783, 0.31079388, -3.751686)
 
-[node name="Dungeon_Wall6" parent="." instance=ExtResource("4_mx8sn")]
-transform = Transform3D(-7.430936e-08, 0, -1.7, 0, 1.7, 0, 1.7, 0, -7.430936e-08, 17, 0, -4)
+[node name="Dungeon_GateDoor13" parent="IronBar_Gates" instance=ExtResource("4_wic5t")]
+transform = Transform3D(-7.430936e-08, 0, 1.7, 0, 1.7, 0, -1.7, 0, -7.430936e-08, -13.470282, 0.31079388, 9.848315)
 
-[node name="Dungeon_Wall7" parent="." instance=ExtResource("4_mx8sn")]
-transform = Transform3D(-7.430936e-08, 0, -1.7, 0, 1.7, 0, 1.7, 0, -7.430936e-08, 17, 0, -17)
+[node name="Dungeon_GateDoor14" parent="IronBar_Gates" instance=ExtResource("4_wic5t")]
+transform = Transform3D(-7.430936e-08, 0, 1.7, 0, 1.7, 0, -1.7, 0, -7.430936e-08, -25.488102, 0.31079388, 9.848316)
+
+[node name="Dungeon_GateDoor10" parent="IronBar_Gates" instance=ExtResource("4_wic5t")]
+transform = Transform3D(-7.430936e-08, 0, 1.7, 0, 1.7, 0, -1.7, 0, -7.430936e-08, -25.451204, 0.31079388, -17.38634)
+
+[node name="Dungeon_GateDoor11" parent="IronBar_Gates" instance=ExtResource("4_wic5t")]
+transform = Transform3D(-7.430936e-08, 0, 1.7, 0, 1.7, 0, -1.7, 0, -7.430936e-08, -25.451202, 0.31079388, -3.751685)
+
+[node name="Dungeon_GateDoor4" parent="IronBar_Gates" instance=ExtResource("4_wic5t")]
+transform = Transform3D(1.7, 0, 0, 0, 1.7, 0, 0, 0, 1.7, 31.903263, 0.31079388, -24.18634)
+
+[node name="Dungeon_GateDoor5" parent="IronBar_Gates" instance=ExtResource("4_wic5t")]
+transform = Transform3D(-7.430936e-08, 0, -1.7, 0, 1.7, 0, 1.7, 0, -7.430936e-08, 39.303715, 0.31079388, -20.982899)
+
+[node name="Dungeon_GateDoor6" parent="IronBar_Gates" instance=ExtResource("4_wic5t")]
+transform = Transform3D(1.7, 0, 0, 0, 1.7, 0, 0, 0, 1.7, 5.6085296, 0.31079388, 16.40509)
+
+[node name="Dungeon_GateDoor7" parent="IronBar_Gates" instance=ExtResource("4_wic5t")]
+transform = Transform3D(1.7, 0, 0, 0, 1.7, 0, 0, 0, 1.7, -19.198805, 0.31079388, 16.40509)

--- a/jamsepticeye-gj/scripts/canvas_overlay.gd
+++ b/jamsepticeye-gj/scripts/canvas_overlay.gd
@@ -1,0 +1,22 @@
+extends Control
+
+@onready var ripple_effect: ColorRect = $RippleEffect
+@onready var vignette_effect: ColorRect = $VignetteEffect
+
+
+func _show_ripple_effect():
+	pass
+	ripple_effect.visible = true
+
+
+func _hide_ripple_effect():
+	pass
+	ripple_effect.visible = false
+
+func _show_vignette_effect():
+	pass
+	vignette_effect.visible = true
+
+func _hide_vignette_effect():
+	pass
+	vignette_effect.visible = false

--- a/jamsepticeye-gj/scripts/canvas_overlay.gd.uid
+++ b/jamsepticeye-gj/scripts/canvas_overlay.gd.uid
@@ -1,0 +1,1 @@
+uid://c0ixa2n2lknay

--- a/jamsepticeye-gj/scripts/ui_manager.gd
+++ b/jamsepticeye-gj/scripts/ui_manager.gd
@@ -11,6 +11,8 @@ enum UI {
 var current_ui : UI = UI.none
 var previous_ui : UI = UI.none
 
+@onready var canvas_overlay: Control = $CanvasOverlay
+
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	switch_ui(UI.main)


### PR DESCRIPTION
Introduces new canvas and spatial shaders for fish-eye, ripple, vignette, and linear depth effects. Adds corresponding ShaderMaterial resources and integrates a CameraOverlay node with effect toggling logic. Updates player and UI manager scenes to support and control these visual effects via a new CanvasOverlay control and script.